### PR TITLE
fix index increment bug

### DIFF
--- a/combinatorial_data/utils.py
+++ b/combinatorial_data/utils.py
@@ -195,6 +195,7 @@ class CombinatorialComplexTransform(BaseTransform):
         ranker: callable,
         dim: int,
         adjacencies: list[str],
+        enable_indexing_bug: bool = False,
     ):
         if isinstance(lifters, list):
             self.lifters = lifters
@@ -203,6 +204,7 @@ class CombinatorialComplexTransform(BaseTransform):
         self.rank = ranker
         self.dim = dim
         self.adjacencies = adjacencies
+        self.enable_indexing_bug = enable_indexing_bug
 
     def __call__(self, graph: Data) -> CombinatorialComplexData:
         if not torch.is_tensor(graph.x):
@@ -213,7 +215,11 @@ class CombinatorialComplexTransform(BaseTransform):
         # get relevant dictionaries using the Rips complex based on the geometric graph/point cloud
         x_dict, mem_dict, adj_dict, inv_dict = self.get_relevant_dicts(graph)
 
-        com_com_data = CombinatorialComplexData()
+        if self.enable_indexing_bug:
+            com_com_data = LegacyCombinatorialComplexData()
+        else:
+            com_com_data = CombinatorialComplexData()
+
         com_com_data = com_com_data.from_dict(graph.to_dict())
 
         for k, v in x_dict.items():

--- a/main_qm9.py
+++ b/main_qm9.py
@@ -140,6 +140,14 @@ if __name__ == "__main__":
     parser.add_argument("--num_samples", type=int, default=None, help="num samples to to train on")
     parser.add_argument("--seed", type=int, default=42, help="random seed")
 
+    # Other arguments
+    parser.add_argument(
+        "--enable_indexing_bug",
+        action="store_true",
+        help="""If the buggy legacy implementation should be used for the combinatorial complex
+             transform. Needed to reproduce EMSPN.""",
+    )
+
     parsed_args = parser.parse_args()
     parsed_args.adjacencies = get_adjacency_types(parsed_args.dim, parsed_args.connectivity)
     parsed_args.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/qm9/utils.py
+++ b/qm9/utils.py
@@ -49,7 +49,11 @@ def generate_loaders_qm9(args: Namespace) -> tuple[DataLoader, DataLoader, DataL
     lifters = get_lifters(args)
     ranker = get_ranker(args.lifters)
     transform = CombinatorialComplexTransform(
-        lifters=lifters, ranker=ranker, dim=args.dim, adjacencies=args.adjacencies
+        lifters=lifters,
+        ranker=ranker,
+        dim=args.dim,
+        adjacencies=args.adjacencies,
+        enable_indexing_bug=args.enable_indexing_bug,
     )
     dataset = QM9(root=data_root)
     dataset = dataset.shuffle()


### PR DESCRIPTION
This small PR addresses the recently discovered bug, detailed in #17. The PR fixes the bug by modifying the `__inc__` method of `CombinatorialComplexData` such that the `x_i` tensors are also incremented. Furthermore, the PR introduces a script argument (`--enable_indexing_bug`) such that we can choose to use the buggy version, in order to be able to reproduce EMPSN.

I trained a few models on subsets of data with the exact same specs twice, once with the bug enabled and once with it fixed. In all specs, the fixed version achieved better performance. This is further evidence that what we observed was indeed a bug.