### PR TITLE
Add supercell

### DIFF
--- a/src/combinatorial_data/lifts.py
+++ b/src/combinatorial_data/lifts.py
@@ -43,6 +43,48 @@ def clique_lift(graph_data) -> set[frozenset[int]]:
     return simplices
 
 
+def edge_lift(graph: Data) -> set[frozenset[int]]:
+    """
+    Identify edges in a graph.
+
+    This function returns the edges of the given graph. Each edge is represented as a list of two
+    node indices.
+
+    Parameters
+    ----------
+    graph : Data
+        The input graph represented as a PyTorch Geometric Data object.
+
+    Returns
+    -------
+    set[frozenset[int]]
+        A set of graph elements, where each element is an edge (frozenset of two node indices).
+
+    Raises
+    ------
+    ValueError
+        If the input graph does not contain an edge index 'edge_index'.
+
+    Notes
+    -----
+    The function directly works with the PyTorch Geometric Data object. Edges are inferred from the
+    edge_index attribute.
+    """
+
+    if (not hasattr(graph, "edge_index")) or (graph.edge_index is None):
+        raise ValueError("The given graph does not have an edge index 'edge_index'!")
+
+    # Create edges
+    edges = {
+        frozenset(edge)
+        for edge in graph.edge_index.t().tolist()
+        if len(edge) == 2
+        if edge[0] != edge[1]
+    }
+
+    return edges
+
+
 def functional_group_lift(graph: Data) -> set[frozenset[int]]:
     """
     Identify functional groups within a molecule and returns them as lists of atom indices.
@@ -89,12 +131,12 @@ def functional_group_lift(graph: Data) -> set[frozenset[int]]:
         return set()
 
 
-def identity_lift(graph: Data) -> set[frozenset[int]]:
+def node_lift(graph: Data) -> set[frozenset[int]]:
     """
-    Identify nodes and edges in a graph.
+    Identify nodes in a graph.
 
-    This function returns the nodes and edges of the given graph. Each node is represented as a
-    singleton list containing its index, and each edge is represented as a list of two node indices.
+    This function returns the nodes of the given graph. Each node is represented as a
+    singleton list containing its index.
 
     Parameters
     ----------
@@ -104,33 +146,26 @@ def identity_lift(graph: Data) -> set[frozenset[int]]:
     Returns
     -------
     set[frozenset[int]]
-        A set of graph elements, where each element is a node (singleton frozenset) or an edge
-        (frozenset of two node indices).
+        A set of graph elements, where each element is a node (singleton frozenset).
 
     Raises
     ------
     ValueError
-        If the input graph does not contain a feature matrix 'x' or an edge index 'edge_index'.
+        If the input graph does not contain a feature matrix 'x'.
 
     Notes
     -----
     The function directly works with the PyTorch Geometric Data object. Nodes are inferred from the
-    x attribute, and edges are inferred from the edge_index attribute.
+    x attribute.
     """
 
     if (not hasattr(graph, "x")) or (graph.x is None):
         raise ValueError("The given graph does not have a feature matrix 'x'!")
-    if (not hasattr(graph, "edge_index")) or (graph.edge_index is None):
-        raise ValueError("The given graph does not have an edge index 'edge_index'!")
 
     # Create nodes
     nodes = {frozenset([node]) for node in range(graph.x.size(0))}
 
-    # Create edges
-    edges = {frozenset(edge) for edge in graph.edge_index.t().tolist()}
-
-    # Combine nodes and edges
-    return nodes.union(edges)
+    return nodes
 
 
 def supercell_lift(graph: Data) -> set[frozenset[int]]:
@@ -256,9 +291,12 @@ def rips_lift(graph: Data, dim: int, dis: float, fc_nodes: bool = True) -> set[f
 
 
 lifter_registry = {
+    "atom": node_lift,  # atom is an alias for node
+    "bond": edge_lift,  # bond is an alias for edge
     "clique": clique_lift,
+    "edge": edge_lift,
     "functional_group": functional_group_lift,
-    "identity": identity_lift,
+    "node": node_lift,
     "ring": ring_lift,
     "rips": rips_lift,
     "supercell": supercell_lift,

--- a/tests/unit/combinatorial_data/test_lifts.py
+++ b/tests/unit/combinatorial_data/test_lifts.py
@@ -73,56 +73,73 @@ def test_clique_lift(edge_index, expected_simplices):
 
 
 @pytest.mark.parametrize(
-    "edge_index, x, expected_output",
+    "edge_index, expected",
     [
         # Test with an empty graph
-        (torch.tensor([[], []], dtype=torch.long), torch.tensor([], dtype=torch.float), set()),
-        # Test with a graph with isolated nodes
+        (torch.tensor([[], []], dtype=torch.long), set()),
+        # Test with a simple graph
         (
             torch.tensor([[0, 2], [1, 3]], dtype=torch.long),
+            {
+                frozenset([0, 1]),
+                frozenset([2, 3]),
+            },
+        ),
+        # Test with a graph with self-loops
+        (
+            torch.tensor([[0, 1, 1], [0, 1, 2]], dtype=torch.long),
+            {
+                frozenset([1, 2]),
+            },
+        ),
+        # Test with missing edge_index
+        (None, ValueError),
+    ],
+)
+def test_edge_lift(edge_index, expected):
+    # Call the edge_lift function
+    if expected is ValueError:
+        with pytest.raises(ValueError):
+            graph_data = Data(edge_index=edge_index)
+            edge_lift(graph_data)
+    else:
+        graph_data = Data(edge_index=edge_index)
+        output = edge_lift(graph_data)
+        assert output == expected
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        # Test with an empty graph
+        (torch.tensor([], dtype=torch.float), set()),
+        # Test with a normal graph
+        (
             torch.tensor([[-1], [-1], [-1], [-1]], dtype=torch.float),
             {
                 frozenset([0]),
                 frozenset([1]),
                 frozenset([2]),
                 frozenset([3]),
-                frozenset([0, 1]),
-                frozenset([2, 3]),
             },
         ),
         # Test with a graph with no feature matrix
         (
-            torch.tensor([[0, 2], [1, 3]], dtype=torch.long),
             None,
             ValueError,
         ),
-        # Test with a graph with self-loops
-        (
-            torch.tensor([[0, 1, 1], [0, 1, 2]], dtype=torch.long),
-            torch.tensor([[-1], [-1], [-1]], dtype=torch.float),
-            {
-                frozenset([0]),
-                frozenset([1]),
-                frozenset([2]),
-                frozenset([1, 2]),
-            },
-        ),
     ],
 )
-def test_identity_lift(edge_index, x, expected_output):
-    if expected_output is ValueError:
+def test_node_lift(x, expected):
+    # Call the node_lift function
+    if expected is ValueError:
         with pytest.raises(ValueError):
-            graph_data = Data(edge_index=edge_index, x=x)
-            identity_lift(graph_data)
+            graph_data = Data(x=x)
+            node_lift(graph_data)
     else:
-        # Create the graph
-        graph_data = Data(edge_index=edge_index, x=x)
-
-        # Call the identity_lift function
-        output = identity_lift(graph_data)
-
-        # Check if the returned output matches the expected output
-        assert output == expected_output
+        graph_data = Data(x=x)
+        output = node_lift(graph_data)
+        assert output == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces the following changes:
- add `supercell_lift()`. "supercell" refers to one cell that contains all nodes. (20a9c64)
- refactor `identity_lift()` into `node_lift()` and edge_lift(). This will allow us to emulate `EGNN`. (9c9aa96)