### PR TITLE
add post_pool_filter

### DIFF
--- a/src/main_qm9.py
+++ b/src/main_qm9.py
@@ -132,7 +132,13 @@ if __name__ == "__main__":
         default="adjacency",
         help="how adjacency between cells of same rank is defined",
     )
-
+    parser.add_argument(
+        "--post_pool_filter",
+        nargs="+",
+        type="int",
+        default=None,
+        help="specifies which ranks to feed into the final prediction",
+    )
     # Optimizer parameters
     parser.add_argument("--lr", type=float, default=5e-4, help="learning rate")
     parser.add_argument("--weight_decay", type=float, default=1e-16, help="learning rate")

--- a/src/utils.py
+++ b/src/utils.py
@@ -157,6 +157,7 @@ def get_model(args: Namespace) -> nn.Module:
             max_dim=args.dim,
             adjacencies=args.adjacencies,
             initial_features=args.initial_features,
+            post_pool_filter=args.post_pool_filter,
         )
     else:
         raise ValueError(f"Model type {args.model_name} not recognized.")


### PR DESCRIPTION
This PR adds a script argument `--post_pool_filter` that allows us to specify a list of ranks whose cells should be used to make the final prediction. By default, cells of all ranks are used. By setting `post_pool_filter 0`, we can now ensure that only atom representations would be used. 

The main purpose of this argument is to be able to simulate EGNN with our codebase. We want to add the supercell to get fully-connected ranks but do not want the supercell itself to influence the final prediction.