### PR TITLE
Separate dataset creation

### DIFF
--- a/scripts/experiments/1_create_dataset.sh
+++ b/scripts/experiments/1_create_dataset.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# isolated ranks: atoms + bonds
+
+# DEFINE EXP ARGUMENTS
+LIFTERS=("atom:0" "bond:1" "supercell:2")
+NEIGHBOR_TYPES="max"
+CONNECTIVITY="self"
+VISIBLE_DIMS=(0 1)
+INITIAL_FEATURES="hetero"
+DIM=2
+
+
+# Train EGNN in parallel for each TARGET_NAME
+python src/create_dataset.py --lifters "${LIFTERS[@]}" \
+                             --neighbor_types "$NEIGHBOR_TYPES" \
+                             --connectivity "$CONNECTIVITY" \
+                             --visible_dims "${VISIBLE_DIMS[@]}" \
+                             --initial_features "$INITIAL_FEATURES" \
+                             --dim "$DIM" \
+                       
+                        
+                        
+                        
+
+

--- a/src/create_dataset.py
+++ b/src/create_dataset.py
@@ -1,0 +1,14 @@
+import argparse
+
+import parser_utils
+from qm9.utils import process_qm9_dataset
+from utils import set_seed
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser = parser_utils.add_common_arguments(parser)
+    parsed_args = parser.parse_args()
+    parsed_args = parser_utils.add_common_derived_arguments(parsed_args)
+
+    set_seed(parsed_args.seed)
+    process_qm9_dataset(parsed_args)

--- a/src/parser_utils.py
+++ b/src/parser_utils.py
@@ -1,0 +1,74 @@
+import argparse
+
+from combinatorial_data.lifter import Lifter
+from qm9.lifts.registry import lifter_registry
+from utils import get_adjacency_types, merge_adjacencies
+
+
+def add_common_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--lifters",
+        nargs="+",
+        help="List of lifters to apply and their ranking logic.",
+        default=["identity:c", "functional_group:2", "ring:2"],
+        required=True,
+    )
+    parser.add_argument(
+        "--neighbor_types",
+        nargs="+",
+        type=str,
+        default=["+1"],
+        help="""Defines adjacency between cells of the same rank. Default is '+1'. Two cells of rank
+                i are connected if they are both connected to the same cell of rank i+1.""",
+    )
+    parser.add_argument(
+        "--connectivity",
+        type=str,
+        default="self_and_next",
+        help="Connectivity pattern between ranks.",
+    )
+    parser.add_argument(
+        "--visible_dims",
+        nargs="+",
+        type=int,
+        default=None,
+        help="Specifies which ranks to explicitly represent as nodes. Default is None.",
+    )
+    parser.add_argument(
+        "--merge_neighbors",
+        action="store_true",
+        default=False,
+        help="""If set, all the neighbors of different types will be represented as a single
+             adjacency matrix.""",
+    )
+    parser.add_argument(
+        "--initial_features",
+        nargs="+",
+        type=str,
+        default=["node"],
+        help="Features to use.",
+    )
+    parser.add_argument("--dim", type=int, default=2, help="ASC dimension.")
+    parser.add_argument("--dis", type=float, default=4.0, help="Radius for Rips complex.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility.")
+
+    return parser
+
+
+def add_common_derived_arguments(parsed_args):
+    parsed_args.adjacencies = get_adjacency_types(
+        parsed_args.dim,
+        parsed_args.connectivity,
+        parsed_args.neighbor_types,
+        parsed_args.visible_dims,
+    )
+    # If merge_neighbors is True, the adjacency types we feed to the model will be the merged ones
+    if parsed_args.merge_neighbors:
+        parsed_args.processed_adjacencies = merge_adjacencies(parsed_args.adjacencies)
+    else:
+        parsed_args.processed_adjacencies = parsed_args.adjacencies
+
+    parsed_args.initial_features = sorted(parsed_args.initial_features)
+    parsed_args.lifter = Lifter(parsed_args, lifter_registry)
+
+    return parsed_args


### PR DESCRIPTION
## Description
The purpose of this PR is to separate dataset creation from model training. Currently, the training script checks if the dataset was already created and if not, creates it on the fly and stores it to disk. This approach does not work well when we want to launch multiple training jobs that use the same dataset, because we get race conditions and recomputation. Furthermore, we spend +1 hour in a GPU node without using GPU resources. 

## List of changes:
- `create_dataset.py`: This script accepts arguments relevant to dataset creation, creates and stores the corresponding dataset. It does not create the dataset if it already exists.
- `scripts/experiments/1_create_dataset.sh`: an example bash script meant to showcase how `create_dataset.py` should be called.
- `parser_utils.py`: This file contains the parser logic that is shared by `create_dataset.py` and `main_qm9.py`, such that we do not define the same arguments twice, for example.
- `main_qm9.py` no longer attempts to create the dataset. It checks if the dataset exists, and otherwise throws a `FileNotFoundError`. This change is implemented in `qm9/utils.py`.
- 